### PR TITLE
Add TSLA/USD pricefeed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 # NEAR options
 NEAR_NO_LOGS = true
-NEAR_CREDENTIALS_STORE_PATH =
+NEAR_CREDENTIALS_STORE_PATH = "~/.near-credentials/"
 
 # Aurora options
-AURORA_PRIVATE_KEY =
+AURORA_PRIVATE_KEY = "0x..."
 
 # Node options
 APP_CONFIG_LOCATION = './appconfig.json'

--- a/appconfig.json
+++ b/appconfig.json
@@ -6,44 +6,25 @@
             "privateKeyEnvKey": "AURORA_PRIVATE_KEY",
             "chainId": 1313161554,
             "rpc": "https://mainnet.aurora.dev"
-        },
-        {
-            "type": "near",
-            "networkId": "near-testnet",
-            "credentialsStorePathEnvKey": "NEAR_CREDENTIALS_STORE_PATH",
-            "networkType": "testnet",
-            "rpc": "https://rpc.testnet.near.org",
-            "maxGas": "300000000000000",
-            "accountId": "{{YOUR_ACCOUNT_ID_HERE}}",
-            "storageDeposit": "300800000000000000000000"
         }
     ],
     "pairs": [
         {
-            "description": "Anyone can transmit() an answer to me, I'm a FluxPriceFeed without access control!",
-            "pair": "ETH / USD",
-            "contractAddress": "0x8BAac7F07c86895cd017C8a2c7d3C72cF9f1051F",
+            "description": "TSLA / USD pricefeed contract",
+            "pair": "TSLA / USD",
+            "contractAddress": "0x39c37b1B416E995bfF040a71892E2be0F9C7dAae",
             "sources": [
                 {
-                    "source_path": "market_data.current_price.usd",
-                    "end_point": "https://api.coingecko.com/api/v3/coins/ethereum"
+                    "source_path": "quoteResponse.result[0].regularMarketPrice",
+                    "end_point": "https://yfapi.net/v6/finance/quote?symbols=TSLA",
+                    "http_method": "GET",
+                    "http_headers": {
+                        "x-api-key": "yahoo-finance-api-key"
+                    }
                 }
             ],
-            "interval": 5000,
-            "networkId": "aurora"
-        },
-        {
-            "description": "ETH / USD for NEAR",
-            "pair": "ETH / USD",
-            "contractAddress": "fpo3.franklinwaller2.testnet",
-            "sources": [
-                {
-                    "source_path": "market_data.current_price.usd",
-                    "end_point": "https://api.coingecko.com/api/v3/coins/ethereum"
-                }
-            ],
-            "interval": 5000,
-            "networkId": "near-testnet",
+            "interval": 60000,
+            "networkId": "aurora",
             "defaultDecimals": 6
         }
     ]


### PR DESCRIPTION
**DO NOT MERGE**

We'll need a different aggregator contract + oracle node for each pricefeed.

Deployment steps:
1. Deploy aggregator contract to Aurora from https://github.com/kreskohq/flux-price-feeds (see README) and save deployed contract address. Sample deployed contract available [here](https://explorer.mainnet.aurora.dev/address/0xFEc2E790d199ae3247318175985E0e1838E8eB0A/transactions).
2. Get deployer's Aurora private key from step 1 using helper command available in flux-price-feeds repo
3. In this repo run `cp .env.example .env` and populate private key into field `AURORA_PRIVATE_KEY`
4. In appconfig.json replace `TSLA/USD` pair's contract address with the aggregator contract address from step 1
5. In appconfig.json plug YahooFinance API key into field `http_headers.x-api-key`. Can update the ticker by changing the `symbol` at the end of the `sources.end_point` field.
6. Run with `npm run start`

Interval is set to run every minute. Can monitor the YahooFinance API request limit from their dashboard.

